### PR TITLE
Update group select to reflect different transparency and color values

### DIFF
--- a/js/controls.js
+++ b/js/controls.js
@@ -197,9 +197,10 @@ const Controls = () =>
         groupSelect.innerHTML = '';
 
         for (let group of modelInfo.animation.groups) {
+            console.log(group);
             let option = document.createElement('option');
-            option.value = group;
-            option.appendChild(document.createTextNode(group));
+            option.value = group.name;
+            option.appendChild(document.createTextNode(group.name));
             groupSelect.appendChild(option);
         }
 
@@ -265,6 +266,7 @@ const Controls = () =>
         // Model controls
         modelCtrls.querySelector('.toggle[for="model-controls"]').addEventListener('click', handleMenuToggle);
         modelSelect.addEventListener('change', handleModelSelect);
+        groupSelect.addEventListener('change', handleGroupSelect);
 
         for (let i = 0; i < colorControls.length; i++) {
             colorControls[i].addEventListener('click', handleColor);
@@ -373,6 +375,24 @@ const Controls = () =>
 
 
     /*
+     * handleGroupSelect
+     *
+     * param evt - Javascript evt
+     *
+     * ...
+     */
+    function handleGroupSelect(evt) {
+        const groupName = groupSelect.value;
+        const modelInfo = visualizers[getCurrentActive()];
+        for (const group of modelInfo.animation.groups) {
+            if (group.name == groupName) {
+                transparency.value = group.transparency;
+            }
+        }
+    }
+
+
+    /*
      * handleColor:
      *
      * param evt - Javascript evt
@@ -448,6 +468,14 @@ const Controls = () =>
      */
     function handleTransparency(evt) {
         let groupName = groupSelect.value;
+        // Save local value of transparency to be applied when group is selected
+        const modelInfo = visualizers[getCurrentActive()];
+        for (const group of modelInfo.animation.groups) {
+            if (group.name == groupName) {
+                group.transparency = transparency.value;
+            }
+        }
+        // Do the actual change
         activeVisualizer.changeTransparency(groupName, parseFloat(evt.target.value));
     }
 

--- a/js/controls.js
+++ b/js/controls.js
@@ -197,7 +197,6 @@ const Controls = () =>
         groupSelect.innerHTML = '';
 
         for (let group of modelInfo.animation.groups) {
-            console.log(group);
             let option = document.createElement('option');
             option.value = group.name;
             option.appendChild(document.createTextNode(group.name));

--- a/js/visualizer.js
+++ b/js/visualizer.js
@@ -333,7 +333,11 @@ const Visualizer = (fps) =>
             groups = [];
 
         for (const group of animation.model.children) {
-            groups.push(group.name);
+            let groupObj = {};
+            groupObj.name = group.name;
+            groupObj.transparency = group.children[0].material.opacity;
+            groupObj.color = group.children[0].material.color;
+            groups.push(groupObj);
         }
 
         return {


### PR DESCRIPTION
Saved the value of transparency and color to be used when we select a different group. This is saved both in the Visulizer and the controls since I couldn't find another way to access the local values of them when I have no access to the animation after creating it.